### PR TITLE
계정정보 가져오기, 수정, 저장 로직 구현 완료, 채널삭제 모달창 파일추가, 구현중

### DIFF
--- a/public/data/accountInfoData.json
+++ b/public/data/accountInfoData.json
@@ -6,11 +6,11 @@
     "kor_name": "김철수",
     "eng_name": "Dunc Abrahamowitcz",
     "profile_image": "https://images.unsplash.com/photo-1666904366306-c8aab5d1006f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDF8dG93SlpGc2twR2d8fGVufDB8fHx8&auto=format&fit=crop&w=900&q=60",
-    "default_email": "dabrahamowitcz0@bravesites.com",
+    "email": "dabrahamowitcz0@bravesites.com",
     "external_email": null,
     "introduction": null,
     "description": null,
-    "nickName": "코난",
+    "nickname": "코난",
     "website_url": null,
     "created_at": "2022-11-02T12:13:34.000Z",
     "updated_at": "2022-11-03T07:58:30.000Z"

--- a/src/Router.js
+++ b/src/Router.js
@@ -7,7 +7,6 @@ import CardDetailContent from './components/CardDetailContent/CardDetailContent'
 import Channel from './components/Channel/Channel';
 import Join from './components/Join/Join';
 import Login from './components/Login/Login';
-import Test from './Test';
 
 const Router = () => {
   const [isLogin, setIsLogin] = useState(false);
@@ -40,7 +39,6 @@ const Router = () => {
         <Route path="/myChannel" element={<Channel />} />
         <Route path="/user/signup" element={<Join />} />
         <Route path="/user/login" element={<Login />} />
-        <Route path="/test" element={<Test />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/AccountInfo/AccountInfo.js
+++ b/src/components/AccountInfo/AccountInfo.js
@@ -1,18 +1,21 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './AccountInfo.scss';
+import DeleteModal from './DeleteModal/DeleteModal';
 
 const AccountInfo = () => {
   const navigate = useNavigate();
+  const [modalOpen, setModalOpen] = useState(false);
   const [accountInfo, setAccountInfo] = useState({
     login_id: '',
     kor_name: '',
     eng_name: '',
-    default_email: '',
-    nickName: '',
+    email: '',
+    nickname: '',
     profile_image: '',
   });
 
+  //accountInfo에 변화가 생겼을 때(수정)
   const onChange = e => {
     const { name, value } = e.target;
     setAccountInfo({
@@ -21,30 +24,46 @@ const AccountInfo = () => {
     });
   };
 
+  //목데이터 fetch
+  // useEffect(() => {
+  //   fetch('data/accountInfoData.json')
+  //     .then(res => res.json())
+  //     .then(result => setAccountInfo(result.data));
+  // }, []);
+
+  //계정정보 fetch
   useEffect(() => {
-    fetch('/data/accountInfoData.json')
+    fetch('http://localhost:8000/user/accountInfo', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        token: localStorage.getItem('token'),
+      },
+    })
       .then(res => res.json())
-      .then(res => {
-        setAccountInfo(res.data);
-      });
+      .then(result => setAccountInfo(result.data));
   }, []);
 
-  // useEffect(() => {
-  //   const saveAccountInfo = e => {
-  //     e.preventDefault();
-  //     fetch('http://localhost:8000/users/signin', {
-  //       method: 'POST',
-  //       headers: {
-  //         'Content-Type': 'application/json',
-  //       },
-  //       body: JSON.stringify({
-  //         accountInfo,
-  //       }),
-  //     })
-  //       .then(res => res.json())
-  //       .then(res => localStorage.setItem('token', res.token));
-  //   };
-  // });
+  // 삭제 모달창 노출
+  const showModal = e => {
+    e.preventDefault();
+    setModalOpen(true);
+  };
+
+  //수정된 계정정보 서버로 저장
+  const saveAccountInfo = e => {
+    e.preventDefault();
+    fetch('http://localhost:8000/user/accountInfo', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        token: localStorage.getItem('token'),
+      },
+      body: JSON.stringify(accountInfo),
+    })
+      .then(res => res.json())
+      .then(result => localStorage.setItem('token', result.token));
+  };
 
   return (
     <div>
@@ -102,10 +121,10 @@ const AccountInfo = () => {
                       <div className="account-info-not-null">*</div>
                       <div className="account-info-title">이메일</div>
                       <input
-                        name="default_email"
+                        name="email"
                         type="text"
                         onChange={onChange}
-                        defaultValue={accountInfo?.default_email}
+                        defaultValue={accountInfo?.email}
                         placeholder="포토폴리오 소식을 받을 이메일을 입력해주세요."
                       />
                     </td>
@@ -114,14 +133,13 @@ const AccountInfo = () => {
                 <tbody>
                   <tr>
                     <td>
-                      <div className="account-info-title special only">
-                        닉네임
-                      </div>
+                      <div className="account-info-not-null">*</div>
+                      <div className="account-info-title">닉네임</div>
                       <input
-                        name="nickName"
+                        name="nickname"
                         type="text"
                         onChange={onChange}
-                        defaultValue={accountInfo?.nickName}
+                        defaultValue={accountInfo?.nickname}
                         placeholder="닉네임을 입력해주세요."
                       />
                     </td>
@@ -170,7 +188,10 @@ const AccountInfo = () => {
                 <b> 네이버 회원 탈퇴 혹은 직접 삭제 전까지 보관됩니다.</b>
               </div>
               <div className="account-info-btn-wrapper">
-                <button className="btn account-info-save-btn">
+                <button
+                  className="btn account-info-save-btn"
+                  onClick={saveAccountInfo}
+                >
                   동의 및 저장
                 </button>
                 <button
@@ -179,7 +200,15 @@ const AccountInfo = () => {
                 >
                   취소
                 </button>
-                <button className="btn account-info-wdraw-btn">채널삭제</button>
+                <div>
+                  <button
+                    className="btn account-info-wdraw-btn"
+                    onClick={showModal}
+                  >
+                    채널삭제
+                  </button>
+                  {modalOpen && <DeleteModal setModalOpen={setModalOpen} />}
+                </div>
               </div>
             </form>
           </div>

--- a/src/components/AccountInfo/AccountInfo.js
+++ b/src/components/AccountInfo/AccountInfo.js
@@ -3,13 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import './AccountInfo.scss';
 
 const AccountInfo = () => {
-  // const login_id = useRef();
-  // const kor_name = useRef();
-  // const eng_name = useRef();
-  // const default_email = useRef();
-  // const nickName = useRef();
-  // const profile_image = useRef();
-
   const navigate = useNavigate();
   const [accountInfo, setAccountInfo] = useState({
     login_id: '',
@@ -19,7 +12,6 @@ const AccountInfo = () => {
     nickName: '',
     profile_image: '',
   });
-  console.log(accountInfo);
 
   const onChange = e => {
     const { name, value } = e.target;
@@ -37,25 +29,22 @@ const AccountInfo = () => {
       });
   }, []);
 
-  // const saveAccountInfo = e => {
-  //   e.preventDefault();
-  //   fetch('http://localhost:8000/users/signin', {
-  //     method: 'POST',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //     body: JSON.stringify({
-  //       login_id: login_id.current.value,
-  //       kor_name: kor_name.current.value,
-  //       eng_name: loeng_namegin_id.current.value,
-  //       default_email: default_email.current.value,
-  //       nickName: nickName.current.value,
-  //       profile_image: profile_image.current.value,
-  //     }),
-  //   })
-  //     .then(res => res.json())
-  //     .then(result => localStorage.setItem('token', result.token));
-  // };
+  // useEffect(() => {
+  //   const saveAccountInfo = e => {
+  //     e.preventDefault();
+  //     fetch('http://localhost:8000/users/signin', {
+  //       method: 'POST',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //       },
+  //       body: JSON.stringify({
+  //         accountInfo,
+  //       }),
+  //     })
+  //       .then(res => res.json())
+  //       .then(res => localStorage.setItem('token', res.token));
+  //   };
+  // });
 
   return (
     <div>

--- a/src/components/AccountInfo/AccountInfo.scss
+++ b/src/components/AccountInfo/AccountInfo.scss
@@ -39,9 +39,6 @@
         .special {
           padding-left: 7.89px;
         }
-        .only {
-          margin-right: 7.89px;
-        }
         .account-info-id {
           display: inline;
           font-size: 12px;

--- a/src/components/AccountInfo/DeleteModal/DeleteModal.js
+++ b/src/components/AccountInfo/DeleteModal/DeleteModal.js
@@ -1,0 +1,41 @@
+import './DeleteModal.scss';
+
+const DeleteModal = ({ setModalOpen }) => {
+  // 모달창 off
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <div>
+      <div className="delete-modal-wrapper">
+        <h2 className="delete-modal-title">채널 삭제를 하면,</h2>
+        <p className="delete-modal-content">
+          <br /> 회원님의 작품과 큐레이션 등 모든 정보가 삭제되며 복구할 수
+          없습니다. <br />
+          또한 다른 사람에게 큐레이션된 작품, 사람들과 이야기 나눈 댓글도 모두
+          삭제됩니다. <br />
+          단, 콜라보레이션에 당선된 작품은 별도로 보관됩니다. <br />
+          외부로 공유된 회원님의 프로필 페이지와 작품 상세 페이지에 접속할 수
+          없습니다.
+          <br />
+          콘텐츠샵 판매자로 가입되어 있는 경우, 먼저 판매자 탈퇴가 되어야
+          포토폴리오 채널 삭제가 가능합니다. ​<br />
+          ​후원 창작자센터에 가입되어 있는 경우, 먼저 창작자센터에서 탈퇴가
+          되어야 포토폴리오 채널 삭제가 가능합니다. <br />
+        </p>
+        <div className="delete-modal-input-wrapper">
+          <input type="checkbox" />
+          <p>위의 내용을 숙지했으며 채널 삭제에 동의합니다.</p>
+        </div>
+        <div className="delete-modal-btn-wrapper">
+          <button className="delete-modal-delete-btn">채널 삭제</button>
+          <button className="delete-modal-cancel-btn" onClick={closeModal}>
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default DeleteModal;

--- a/src/components/AccountInfo/DeleteModal/DeleteModal.scss
+++ b/src/components/AccountInfo/DeleteModal/DeleteModal.scss
@@ -1,0 +1,35 @@
+.delete-modal-wrapper {
+  width: 532px;
+  height: 362.69px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 1000;
+  border-radius: 4px;
+  background-color: #fff;
+  .delete-modal-title {
+    font-size: 14px;
+    font-weight: bold;
+    color: #1a1a1a;
+  }
+  .delete-modal-content {
+    font-size: 13px;
+    color: #1a1a1a;
+  }
+  .delete-modal-input-wrapper {
+    display: flex;
+    input {
+      transform: scale(0.4);
+    }
+    p {
+      font-size: 12px;
+      color: #858585;
+    }
+  }
+  .delete-modal-btn-wrapper {
+    .delete-modal-delete-btn {
+    }
+    .delete-modal-cancel-btn {
+    }
+  }
+}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -11,7 +11,6 @@ function Header() {
   //프로필 이미지 hover 여부 체크
   const [isHovering, setIsHovering] = useState(false);
 
-
   // const [haveProfileImg, setHaveProfileImg] = useState(false);
 
   //login창 로직 추가 코드
@@ -23,7 +22,6 @@ function Header() {
   function clickLoginBtn(event) {
     setOpenLoginPage(true);
   }
-
 
   //localStorage에 token 유무 체크
   const token = localStorage.getItem('token');


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 서버와 통신하여 계정정보를 가져와 뿌려주고, 그 계정정보를 수정하여 다시 저장할 수 있다.
- 회원탈퇴(채널삭제)를 할 수 있다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 계정정보 가져오기 수정, 저장

- useEffect를 통해 데이터를 백엔드 서버와 통신, fetch하여 토큰을 주어 데이터를 가져와, setAccountInfo에 저장하여 뿌려주었다.
- useState함수를 통해 accountInfo의 데이터를 최신상태로 가져올 수 있게 하여주고, 백엔드 서버와 통신, fetch함수를 이용하여 토큰을 보내주어 데이터를 수정, 저장할 수 있도록 구현하였다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- fetch함수의 구조와 사용법을 한번 더 공부할 수 있었다. (생각보다 구조가 복잡하여서 어떻게 변경해야할지 헷갈렸다.)
- useState함수로 객체 변경하는 방법에 대해 배웠다.

<br />

## :: 기타 질문 및 특이 사항

- 없음.
